### PR TITLE
Change google cloud storage bucket name

### DIFF
--- a/landdegradation/util.py
+++ b/landdegradation/util.py
@@ -11,7 +11,7 @@ from landdegradation.schemas.schemas import CloudResults, CloudResultsSchema, Ur
 
 
 # Google cloud storage bucket for output
-BUCKET = "ldmt"
+BUCKET = "ldms"
 
 # Number of minutes a GEE task is allowed to run before timing out and being 
 # cancelled


### PR DESCRIPTION
Creation of Google Cloud Bucket storage on Google cloud platform for storage of intermediate and final datasets generated from qgis plugin executions